### PR TITLE
Parallelize raycasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -280,6 +280,7 @@ dependencies = [
  "console 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -296,7 +297,7 @@ name = "inventory"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ctor 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "ghost 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "inventory-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -409,7 +410,7 @@ dependencies = [
  "rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "simba 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simba 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -763,6 +764,7 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tobj 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -891,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1172,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 "checksum crossbeam-queue 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-"checksum ctor 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
+"checksum ctor 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
 "checksum deflate 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e7e5d2a2273fed52a7f947ee55b092c4057025d7a3e04e5ecdbd25d6c3fb1bd7"
 "checksum dlib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76"
 "checksum downcast-rs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
@@ -1255,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 "checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 "checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
-"checksum simba 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fdb9315f4b2401dfa24c72694ebdda7daa06193395eca6bd262a5d0aa6d74dae"
+"checksum simba 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb931b1367faadea6b1ab1c306a860ec17aaa5fa39f367d0c744e69d971a1fb2"
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,13 @@ more-asserts = "0.2"
 auto_ops = "0.1.0"
 clap = "2.33"
 image = { version = "0.23", default-features = false, features = ["jpeg", "png", "jpeg_rayon"] }
-indicatif = "0.14"
+indicatif = { version = "0.14", features = ["with_rayon"] }
 minifb = "0.16"
 nalgebra = { version = "0.21", features = ["serde-serialize"] }
 num-traits = "0.2"
 once_cell = "1.3.1"
 rand = "0.7"
+rayon = "1.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tobj = "2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,12 @@ mod scene;
 use crate::scene::{RaytracingScene, Scene};
 use clap::{App, Arg};
 use image::RgbaImage;
-use indicatif::ProgressIterator;
+use indicatif::ParallelProgressIterator;
 use indicatif::{ProgressBar, ProgressStyle};
 use minifb::{Key, Window, WindowOptions};
 use nalgebra::Vector4;
 use rand::{seq::SliceRandom, thread_rng};
+use rayon::prelude::*;
 use std::fs::File;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -57,14 +58,14 @@ fn raytrace_fb(
 
         if let Some(progress) = progress {
             indexes
-                .into_iter()
+                .into_par_iter()
                 .progress_with(progress.clone())
                 .inspect(|_| progress.set_message(&rays.load(Ordering::SeqCst).to_string()))
                 .for_each(process_pixel);
 
             progress.finish_with_message(&rays.load(Ordering::SeqCst).to_string());
         } else {
-            indexes.into_iter().for_each(process_pixel);
+            indexes.into_par_iter().for_each(process_pixel);
         }
     });
 }
@@ -97,14 +98,14 @@ fn raytrace(
 
     if let Some(progress) = progress {
         indexes
-            .into_iter()
+            .into_par_iter()
             .progress_with(progress.clone())
             .inspect(|_| progress.set_message(&rays.load(Ordering::SeqCst).to_string()))
             .for_each(process_pixel);
 
         progress.finish_with_message(&rays.load(Ordering::SeqCst).to_string());
     } else {
-        indexes.into_iter().for_each(process_pixel);
+        indexes.into_par_iter().for_each(process_pixel);
     }
 
     start.elapsed()

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod scene;
 use crate::scene::{RaytracingScene, Scene};
 use clap::{App, Arg};
 use image::RgbaImage;
+use indicatif::ProgressIterator;
 use indicatif::{ProgressBar, ProgressStyle};
 use minifb::{Key, Window, WindowOptions};
 use nalgebra::Vector4;
@@ -46,28 +47,24 @@ fn raytrace_fb(
         let rays = AtomicU64::new(0);
         let width = scene.get_width();
 
-        let iter: Box<dyn Iterator<Item = u32>> = if let Some(progress) = &progress {
-            Box::new(progress.wrap_iter(indexes.into_iter()))
-        } else {
-            Box::new(indexes.into_iter())
-        };
-
-        for index in iter {
+        let process_pixel = |index| {
             let (color, r) = scene.screen_raycast(index % width, index / width);
             rays.fetch_add(r, Ordering::SeqCst);
 
-            {
-                let mut buffer = buffer_mutex.lock().unwrap();
-                buffer[index as usize] = to_argb_u32(color);
-            }
-
-            if let Some(progress) = &progress {
-                progress.set_message(&rays.load(Ordering::SeqCst).to_string());
-            }
-        }
+            let mut buffer = buffer_mutex.lock().unwrap();
+            buffer[index as usize] = to_argb_u32(color);
+        };
 
         if let Some(progress) = progress {
-            progress.finish();
+            indexes
+                .into_iter()
+                .progress_with(progress.clone())
+                .inspect(|_| progress.set_message(&rays.load(Ordering::SeqCst).to_string()))
+                .for_each(process_pixel);
+
+            progress.finish_with_message(&rays.load(Ordering::SeqCst).to_string());
+        } else {
+            indexes.into_iter().for_each(process_pixel);
         }
     });
 }
@@ -80,32 +77,34 @@ fn raytrace(
     let mut indexes: Vec<u32> = (0..scene.get_width() * scene.get_height()).collect();
     indexes.shuffle(&mut thread_rng());
 
+    let buffer_mutex = Arc::new(Mutex::new(image_buffer));
     let rays = AtomicU64::new(0);
-    let iter: Box<dyn Iterator<Item = u32>> = if let Some(progress) = &progress {
-        Box::new(progress.wrap_iter(indexes.into_iter()))
-    } else {
-        Box::new(indexes.into_iter())
-    };
-
     let width = scene.get_width();
-    let start = Instant::now();
-    for index in iter {
+
+    let process_pixel = |index| {
         let (color, r) = scene.screen_raycast(index % width, index / width);
         rays.fetch_add(r, Ordering::SeqCst);
 
         let index = (index * 4) as usize;
-        image_buffer[index] = (color.x * 255.0) as u8;
-        image_buffer[index + 1] = (color.y * 255.0) as u8;
-        image_buffer[index + 2] = (color.z * 255.0) as u8;
-        image_buffer[index + 3] = (color.w * 255.0) as u8;
+        let mut buffer = buffer_mutex.lock().unwrap();
+        buffer[index] = (color.x * 255.0) as u8;
+        buffer[index + 1] = (color.y * 255.0) as u8;
+        buffer[index + 2] = (color.z * 255.0) as u8;
+        buffer[index + 3] = (color.w * 255.0) as u8;
+    };
 
-        if let Some(progress) = &progress {
-            progress.set_message(&rays.load(Ordering::SeqCst).to_string());
-        }
-    }
+    let start = Instant::now();
 
     if let Some(progress) = progress {
-        progress.finish();
+        indexes
+            .into_iter()
+            .progress_with(progress.clone())
+            .inspect(|_| progress.set_message(&rays.load(Ordering::SeqCst).to_string()))
+            .for_each(process_pixel);
+
+        progress.finish_with_message(&rays.load(Ordering::SeqCst).to_string());
+    } else {
+        indexes.into_iter().for_each(process_pixel);
     }
 
     start.elapsed()


### PR DESCRIPTION
Parallelizes raycasting across all CPU cores to boost performance further.

Benchmarks on an i7 8650U (8 cores, averaged over 3 runs):
|scene|sequential (old)|parallelized (new)|render time change|
|-|-|-|-|
|`scene.json`|6.308s (4,572,877 rays)|1.603s (4,572,825 rays)|3.94x faster|
|`refraction.json`|2.557s (8,793,354 rays)|826ms (8,792,571 rays)|3.1x faster|
|`mesh_test.json`|7.819s (2,004,244 rays)|1.475s (2,004,244 rays)|5.3x faster|