### PR TITLE
Convert Mutexes to RwLocks and internalize progress bar and framebuffer

### DIFF
--- a/src/render/raytracing_scene.rs
+++ b/src/render/raytracing_scene.rs
@@ -472,12 +472,6 @@ impl RaytracingScene {
     }
 
     pub fn raytrace_to_image(&self, use_progress: bool) -> (RgbaImage, Duration, u64) {
-        let progress = if use_progress {
-            Some(self.build_progress_bar())
-        } else {
-            None
-        };
-
         let width = self.get_width() as usize;
         let height = self.get_height() as usize;
 
@@ -510,7 +504,9 @@ impl RaytracingScene {
         indexes.shuffle(&mut thread_rng());
 
         let start = Instant::now();
-        if let Some(progress) = progress {
+        if use_progress {
+            let progress = self.build_progress_bar();
+
             indexes
                 .par_iter()
                 .progress_with(progress.clone())
@@ -547,12 +543,6 @@ impl RaytracingScene {
     }
 
     pub fn raytrace_to_buffer(self, use_progress: bool) {
-        let progress = if use_progress {
-            Some(self.build_progress_bar())
-        } else {
-            None
-        };
-
         let width = self.get_width() as usize;
         let height = self.get_height() as usize;
 
@@ -598,7 +588,9 @@ impl RaytracingScene {
             let mut indexes: Vec<usize> = (0..width * height).collect();
             indexes.shuffle(&mut thread_rng());
 
-            if let Some(progress) = progress {
+            if use_progress {
+                let progress = self.build_progress_bar();
+
                 indexes
                     .par_iter()
                     .progress_with(progress.clone())

--- a/src/render/raytracing_scene.rs
+++ b/src/render/raytracing_scene.rs
@@ -464,9 +464,12 @@ impl RaytracingScene {
 
         let progress = ProgressBar::new((width * height).into());
         progress.set_draw_delta((width * height / 200).into());
-        progress.set_style(ProgressStyle::default_bar().template(
-            "[{elapsed_precise} elapsed] [{eta_precise} left] {bar:40} {pos}/{len} pixels, {msg} rays",
-        ));
+        progress.set_style(ProgressStyle::default_bar().template(format!(
+            "{} {} {}",
+            "[{elapsed_precise} elapsed] [{eta_precise} left]",
+            "{bar:40}",
+            "{pos}/{len} pixels, {msg} rays",
+        )));
 
         progress
     }

--- a/src/render_scenes.rs
+++ b/src/render_scenes.rs
@@ -43,7 +43,7 @@ fn main() {
             print!("\u{2514} Iteration {}: tracing...", i + 1);
             io::stdout().flush().unwrap();
 
-            let (image, duration, ray_count) = scene.raytrace_to_image(None);
+            let (image, duration, ray_count) = scene.raytrace_to_image(false);
             duration_sum += duration;
             ray_count_sum += ray_count;
 


### PR DESCRIPTION
Converts Rust `Mutexes` to `RwLocks` for better access, cleans up unnecessary `Arcs`, and moves the progress bar and framebuffer construction into the `RaytracingScene` methods. This should make it easier to return stats and be more consistent.